### PR TITLE
docs: fix README config example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sensible.nvim
 
-For a configuration example see [.config/nvim/lua/plugins/sensible.nvim](
-https://github.com/malikbenkirane/.nvim/blob/main/lua/plugins/sensible.nvim).
+For a configuration example see [.config/nvim/lua/plugins/sensible.lua](
+https://github.com/malikbenkirane/.nvim/blob/main/lua/plugins/sensible.lua).
 
 You will need a [push function](
 https://github.com/malikbenkirane/.fish/blob/main/functions/push.fish)


### PR DESCRIPTION
## Summary
- update the README config-example link to the current `lua/plugins/sensible.lua` path in the referenced dotfiles repo
- update the visible link text to match the target path

## Validation
- confirmed the old URL returns 404
- confirmed the replacement URL returns 200
- ran `git diff --check`

Fixes #2
